### PR TITLE
[codex] Add review app hook surfaces

### DIFF
--- a/layouts/base.html
+++ b/layouts/base.html
@@ -275,6 +275,7 @@
     {% include 'partials/side_cart.html' %}
     {% core_js %}
 
+    {% app_hook 'global_social_proof' %}
     {% app_hook 'global_footer' %}
 
 </body>

--- a/partials/recommended_products.html
+++ b/partials/recommended_products.html
@@ -40,6 +40,7 @@
                         <div class="card-title">
                             <a href="{{ product.get_absolute_url }}" title="{{ product.get_title }}" class="text-dark">{{ product.get_title }}</a>
                         </div>
+                        {% app_hook 'product_card_rating_summary' %}
                         {% if settings.product_reviews and product.rating %}
                             <div class="card-text d-flex mb-2">
                                 <div class="catalogue_item-rating-stars">

--- a/templates/catalogue/category.html
+++ b/templates/catalogue/category.html
@@ -40,4 +40,5 @@
         </div>
     {% endif %}
     {{ block.super }}
+    {% app_hook 'collection_review_feed' %}
 {% endblock %}

--- a/templates/catalogue/index.html
+++ b/templates/catalogue/index.html
@@ -58,6 +58,7 @@
                                 </div>
                                 {% endblock %}
                                 {% block product_review %}
+                                    {% app_hook 'product_card_rating_summary' %}
                                     {% if settings.product_reviews and product.rating %}
                                     <div class="card-text d-flex mb-2 fs-8">
                                         <div class="catalogue_item-rating-stars">

--- a/templates/catalogue/product.html
+++ b/templates/catalogue/product.html
@@ -64,6 +64,8 @@
                     {{ product.get_title }}
                 </h1>
 
+                {% app_hook 'product_rating_summary' %}
+
                 {% if settings.product_reviews and product.rating %}
                
                     <div class="my-3">          
@@ -178,6 +180,8 @@
                      {{ product.get_description|safe }}
                 </div>
                 {% endif %}
+
+                {% app_hook 'product_info' %}
             
             </div>
         </div>
@@ -203,9 +207,15 @@
     </div>
 </section>
 {% endif %}
+
+{% app_hook 'product_footer' %}
+
 {% if product.sorted_recommended_products %}
     {% include "partials/recommended_products.html" %}
 {% endif %}
+
+{% app_hook 'product_reviews' %}
+{% app_hook 'product_review_cta' %}
 
 {% if settings.product_reviews %}
 <section id="reviews" class="border-top">
@@ -215,14 +225,12 @@
             <div class="col">
                 <div class="py-5">
                     {% if product.num_approved_reviews == 0 %}
-                        <p>
-                            {% if product|is_review_permitted:user %}
-                                {% url 'catalogue:reviews-add' product_slug=product.slug product_pk=product.id as add_review_url %}
-                                {% t "store.catalogue.no_reviews" %} <a href="{{ add_review_url }}#addreview">{% t "store.catalogue.no_reviews_add" %}</a>.
-                            {% else %}
-                                {% t "store.catalogue.no_reviews" %}.
-                            {% endif %}
-                        </p>
+                        {% if product|is_review_permitted:user %}
+                            {% url 'catalogue:reviews-add' product_slug=product.slug product_pk=product.id as add_review_url %}
+                            <p>{% t "store.catalogue.no_reviews" %} <a href="{{ add_review_url }}#addreview">{% t "store.catalogue.no_reviews_add" %}</a>.</p>
+                        {% else %}
+                            <p>{% t "store.catalogue.no_reviews" %}.</p>
+                        {% endif %}
                     {% else %}
                     <div class="d-flex flex-column flex-md-row align-items-center mb-3">
                         <h4 class="me-3">{% t "store.catalogue.customer_reviews" %}</h4>

--- a/templates/index.html
+++ b/templates/index.html
@@ -179,6 +179,7 @@
                         <div class="card-title">
                             <a href="{{ product.get_absolute_url }}" title="{{ product.get_title }}" class="text-dark">{{ product.get_title }}</a>
                         </div>
+                        {% app_hook 'product_card_rating_summary' %}
                         {% if settings.product_reviews and product.rating %}
                             <div class="card-text d-flex mb-2">
                                 <div class="catalogue_item-rating-stars">
@@ -231,6 +232,8 @@
     </div>
 </section>
 {% endif %}
+
+{% app_hook 'home_review_feed' %}
 
 {% endif %}
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -57,6 +57,9 @@
                             </div>
                             {% endblock %}
                             {% block product_review %}
+                                {% with product=result.object %}
+                                    {% app_hook 'product_card_rating_summary' %}
+                                {% endwith %}
                                 {% if settings.product_reviews and result.object.rating %}
                                 <div class="card-text d-flex mb-2 fs-8">
                                     <div class="catalogue_item-rating-stars">


### PR DESCRIPTION
## Summary
- Adds inert app hook slots for product rating summaries, product review widgets, review CTAs, product-card ratings, collection review feeds, homepage review feeds, and global social proof.
- Preserves native review rendering as fallback and keeps existing view_product/add_to_cart hooks in place.

## Validation
- Ran `git diff --check`.
- No runtime tests were available for this template-only change.